### PR TITLE
Moving to a directory instead of a jar.

### DIFF
--- a/home/pipeline/spring-petclinic.yaml
+++ b/home/pipeline/spring-petclinic.yaml
@@ -116,7 +116,7 @@ jobs:
                   --cluster-builder demo-cluster-builder \
                   --namespace ((petclinic.tbsNamespace)) \
                   --wait \
-                  --local-path target/spring-petclinic-2.3.0.BUILD-SNAPSHOT.jar
+                  --local-path target 
               fi
 
 


### PR DESCRIPTION
by just giving tbs the directory it'll pickup any jar file. You can see an example here: https://github.com/JasonMorgan/tanzu-e2e/blob/main/ci/tasks/handoff-to-tbs.sh

If y'all want to see an example holler at me. I run an example pipeline @ ci.59s.io.

This PR should address Issue #5 