### PR TITLE
Use TLSCertificateDelegation to avoid propagating wildcard certs thro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ You can currently access a hosted version of the E2E workshop here: https://via.
 
 To install the E2E workshop in your own environment, the following prereqs must be in place in your Kubernetes cluster:
 
-**Educates**
-
-Install the educates operator, per these instructions: https://docs.edukates.io/en/latest/getting-started/installing-operator.html
-
-**Ingress**
-
-Set up ingress, with a wildcard DNS domain, that terminates with a signed cert. Contour and LetsEncrypt are great tools for this.
-
 **Environment Values File**
 
 Follow the docs for [Customizing the Environment Values File](install/values/README.md)
+
+**Contour**
+
+Set up Contour, with a wildcard DNS domain, that terminates with a signed cert. LetsEncrypt is a great tool for generating the cert. Follow the docs for [Configuring TLS Certificate Delegation](install/certificate/README.md)
+
+**Educates**
+
+Install the educates operator, per these instructions: https://docs.edukates.io/en/latest/getting-started/installing-operator.html
 
 **Harbor**
 

--- a/install/argocd/argocd-dependencies.yaml
+++ b/install/argocd/argocd-dependencies.yaml
@@ -1,16 +1,5 @@
 #@ load("@ytt:data", "data")
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  namespace: argocd
-  name: contour-tls
-type: kubernetes.io/tls
-data:
-  tls.crt: #@ data.values.ingress.base64_cert
-  tls.key: #@ data.values.ingress.base64_key
-
----
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -29,7 +18,7 @@ spec:
   tls:
     - hosts:
         - #@ "argocd.{}".format(data.values.ingress.domain)
-      secretName: contour-tls
+      secretName: #@ "{}/{}".format(data.values.ingress.contour_tls_namespace,data.values.ingress.contour_tls_secret)
 
 ---
 apiVersion: networking.k8s.io/v1beta1
@@ -50,7 +39,7 @@ spec:
   tls:
     - hosts:
         - #@ "argocd-cli.{}".format(data.values.ingress.domain)
-      secretName: contour-tls
+      secretName: #@ "{}/{}".format(data.values.ingress.contour_tls_namespace,data.values.ingress.contour_tls_secret)
 
 #@ if data.values.psp.cluster_role:
 ---

--- a/install/certificate/README.md
+++ b/install/certificate/README.md
@@ -1,0 +1,11 @@
+# Configuring TLS Certificate Delegation
+
+Ensure that you have prepared a values.yaml file, by customizing the values-example.yaml file in the root of this repo.
+
+From this directory in the repo, execute:
+
+```
+./install-tls-cert.sh /path/to/my/values.yaml
+```
+
+This will ensure that all applications in other namespaces will be able to terminate TLS using your configured wildcard certificate.

--- a/install/certificate/install-tls-cert.sh
+++ b/install/certificate/install-tls-cert.sh
@@ -1,0 +1,1 @@
+ytt -f tls-cert-delegation.yaml -f $1 | kapp deploy -a certificate -f- --diff-changes --yes

--- a/install/certificate/tls-cert-delegation.yaml
+++ b/install/certificate/tls-cert-delegation.yaml
@@ -1,0 +1,12 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: projectcontour.io/v1
+kind: TLSCertificateDelegation
+metadata:
+  name: contour-delegation
+  namespace: #@ data.values.ingress.contour_tls_namespace
+spec:
+  delegations:
+    - secretName: #@ data.values.ingress.contour_tls_secret
+      targetNamespaces:
+        - "*"

--- a/install/concourse/concourse-dependencies.yaml
+++ b/install/concourse/concourse-dependencies.yaml
@@ -1,14 +1,4 @@
 #@ load("@ytt:data", "data")
----
-apiVersion: v1
-kind: Secret
-metadata:
-  namespace: concourse
-  name: contour-tls
-type: kubernetes.io/tls
-data:
-  tls.crt: #@ data.values.ingress.base64_cert
-  tls.key: #@ data.values.ingress.base64_key
 
 #@ if data.values.psp.cluster_role:
 ---

--- a/install/concourse/concourse-helm-values.yaml
+++ b/install/concourse/concourse-helm-values.yaml
@@ -11,7 +11,7 @@ web:
     enabled: true
     hosts: #@ ["concourse.{}".format(data.values.ingress.domain)]
     tls:
-    - secretName: contour-tls
+    - secretName: #@ "{}/{}".format(data.values.ingress.contour_tls_namespace,data.values.ingress.contour_tls_secret)
       hosts: #@ ["concourse.{}".format(data.values.ingress.domain)]
 secrets:
   localUsers: #@ "{}:{}".format(data.values.concourse.username,data.values.concourse.password)

--- a/install/harbor/harbor-dependencies.yaml
+++ b/install/harbor/harbor-dependencies.yaml
@@ -1,17 +1,6 @@
 #@ load("@ytt:data", "data")
 ---
 apiVersion: v1
-kind: Secret
-metadata:
-  namespace: harbor
-  name: contour-tls
-type: kubernetes.io/tls
-data:
-  tls.crt: #@ data.values.ingress.base64_cert
-  tls.key: #@ data.values.ingress.base64_key
-
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   namespace: harbor

--- a/install/harbor/harbor-helm-values.yaml
+++ b/install/harbor/harbor-helm-values.yaml
@@ -4,7 +4,7 @@ expose:
   tls:
     certSource: secret
     secret:
-      secretName: "contour-tls"
+      secretName: #@ "{}/{}".format(data.values.ingress.contour_tls_namespace,data.values.ingress.contour_tls_secret)
   ingress:
     hosts:
       core: #@ "harbor.{}".format(data.values.ingress.domain)

--- a/install/kubeapps/install-kubeapps.sh
+++ b/install/kubeapps/install-kubeapps.sh
@@ -5,4 +5,4 @@ helm repo update
 
 ytt -f kubeapps-helm-values.yaml -f $1 | helm template bitnami/kubeapps --name-template kubeapps -f- > chart.yaml
 
-ytt -f kubeapps-dependencies.yaml -f chart.yaml -f $1 --file-mark 'chart.yaml:type=yaml-plain' | kapp deploy -a kubeapps -n kubeapps -f- --diff-changes --yes
+ytt -f kubeapps-dependencies.yaml -f integrate-contour-overlay.yaml -f chart.yaml -f $1 --file-mark 'chart.yaml:type=yaml-plain' | kapp deploy -a kubeapps -n kubeapps -f- --diff-changes --yes

--- a/install/kubeapps/integrate-contour-overlay.yaml
+++ b/install/kubeapps/integrate-contour-overlay.yaml
@@ -1,0 +1,17 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@ def resource(kind, name):
+kind: #@ kind
+metadata:
+  name: #@ name
+#@ end
+
+#@overlay/match by=overlay.subset(resource("Ingress","kubeapps"))
+---
+spec:
+  tls:
+    #@overlay/match by=overlay.all
+    - secretName: #@ "{}/{}".format(data.values.ingress.contour_tls_namespace,data.values.ingress.contour_tls_secret)
+
+

--- a/install/kubeapps/kubeapps-dependencies.yaml
+++ b/install/kubeapps/kubeapps-dependencies.yaml
@@ -1,14 +1,4 @@
 #@ load("@ytt:data", "data")
----
-apiVersion: v1
-kind: Secret
-metadata:
-  namespace: kubeapps
-  name: #@ "kubeapps.{}-tls".format(data.values.ingress.domain)
-type: kubernetes.io/tls
-data:
-  tls.crt: #@ data.values.ingress.base64_cert
-  tls.key: #@ data.values.ingress.base64_key
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/install/kubeapps/kubeapps-helm-values.yaml
+++ b/install/kubeapps/kubeapps-helm-values.yaml
@@ -4,3 +4,6 @@ ingress:
   enabled: true
   hostname: #@ "kubeapps.{}".format(data.values.ingress.domain)
   tls: true
+postgresql:
+  replication:
+    enabled: false

--- a/install/values/README.md
+++ b/install/values/README.md
@@ -2,6 +2,12 @@
 
 Make a copy of the [values-example.yaml](../../values-example.yaml) file, and customize it for the cluster you will be installing the e2e workshop into. You will use this values file as an input to all subsequent install processes.
 
+**ingress.domain**<br>
+This is the DNS name for the wildcard domain for which you have configured a signed certificate for Ingress.
+**ingress.contour_tls_namespace**<br>
+**ingress.contour_tls_secret**<br>
+Using `kubectl create secret tls`, create a Kubernetes secret that contains the public cert and the private key for your signed certificate. Set these values to the namespace and the name of your created secret.
+
 **concourse.username**<br>
 **concourse.password**<br>
 Set these values to the login credentials for your Concourse server. This user will be a member of the main team.

--- a/values-example.yaml
+++ b/values-example.yaml
@@ -2,14 +2,14 @@
 ---
 ingress:
   domain: <INGRESS-DOMAIN>
-  base64_cert:
-  base64_key:
+  contour_tls_namespace: projectcontour
+  contour_tls_secret: contour-tls
 concourse:
   username: test
   password: <PASSWORD>
 harbor:
   username: admin
-  password: <PASSWORD>
+  password: Harbor12345
   diskSize: 50Gi
 psp:
   cluster_role:


### PR DESCRIPTION
With this change, the wildcard cert can be installed and rotated in a single place in the cluster, and all of the ingress applications (harbor, concourse, kubeapps, argocd, etc.) will leverage it, without needing to put cert info in values.yaml