### PR TITLE
Allow for dynamic generation of TLS Secret in GitOps repo

### DIFF
--- a/base/workshop-tbs-gitops.yaml
+++ b/base/workshop-tbs-gitops.yaml
@@ -45,6 +45,10 @@ spec:
         value: #@ data.values.argocd.adminPassword
       - name: GITEA_PASSWORD
         value: #@ data.values.gitea.adminPassword
+      - name: CONTOUR_TLS_NAMESPACE
+        value: #@ data.values.ingress.contour_tls_namespace
+      - name: CONTOUR_TLS_SECRET
+        value: #@ data.values.ingress.contour_tls_secret
     namespaces:
       budget: x-large
       limits:

--- a/base/workshop-tbs-gitops.yaml
+++ b/base/workshop-tbs-gitops.yaml
@@ -64,11 +64,6 @@ spec:
         vendor: octant
       editor:
         enabled: true
-    dashboards:
-      - name: Harbor
-        url: "$(ingress_protocol)://harbor.$(ingress_domain)"
-      - name: ArgoCD
-        url: "$(ingress_protocol)://argocd.$(ingress_domain)"
     objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding

--- a/home/spring-webdb-config/base/httpproxy.yaml
+++ b/home/spring-webdb-config/base/httpproxy.yaml
@@ -1,3 +1,5 @@
+#@ load("@ytt:data", "data")
+---
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
@@ -6,7 +8,7 @@ spec:
   virtualhost:
     fqdn: default.example.com
     tls:
-      secretName: projectcontour/contour-tls
+      secretName: #@ "{}/{}".format(data.values.ingress.contour_tls_namespace,data.values.ingress.contour_tls_secret)
   routes:
     - services:
         - name: webdb

--- a/home/values.yaml
+++ b/home/values.yaml
@@ -3,3 +3,5 @@
 session:
 ingress:
   domain:
+  contour_tls_namespace:
+  contour_tls_secret:

--- a/home/workshop/content/exercises/gitops-cd.md
+++ b/home/workshop/content/exercises/gitops-cd.md
@@ -2,6 +2,8 @@ In our CI (Continuous Integration) process, we used Tanzu Build Service to synch
 
 Similarly, for our CD (Continuous Delivery) process, we want to use GitOps tooling to synchronize Git deployment repos to the running state of our cluster. Tanzu Advanced Edition works well with any GitOps tooling. For this workshop, we have decided to use ArgoCD. Let's examine the ArgoCD app that will manage deployment of our web application and database.
 
+Log into ArgoCD with username 'admin' and password "{{ ENV_ARGOCD_PASSWORD }}":
+
 ```dashboard:open-url
 url: https://argocd.{{ ingress_domain }}/applications/{{ session_namespace }}
 ```

--- a/home/workshop/setup.d/04-gitops-repo.sh
+++ b/home/workshop/setup.d/04-gitops-repo.sh
@@ -7,7 +7,7 @@ then
   export YTT_session=${SESSION_NAMESPACE}
   export YTT_ingress__domain=${INGRESS_DOMAIN}
   export YTT_ingress__contour_tls_namespace=${CONTOUR_TLS_NAMESPACE}
-  export YTT_ingress__contour_tls_secret=${CONTOUR_TLS_NAMESPACE}
+  export YTT_ingress__contour_tls_secret=${CONTOUR_TLS_SECRET}
 
   ytt -f spring-webdb-config/dev/httpproxy.yaml -f values.yaml --data-values-env YTT | tee httpproxy.yaml
   mv httpproxy.yaml spring-webdb-config/dev/httpproxy.yaml

--- a/home/workshop/setup.d/04-gitops-repo.sh
+++ b/home/workshop/setup.d/04-gitops-repo.sh
@@ -8,6 +8,8 @@ then
   export YTT_ingress__domain=${INGRESS_DOMAIN}
   ytt -f spring-webdb-config/dev/httpproxy.yaml -f values.yaml --data-values-env YTT | tee httpproxy.yaml
   mv httpproxy.yaml spring-webdb-config/dev/httpproxy.yaml
+  ytt -f spring-webdb-config/base/httpproxy.yaml -f values.yaml --data-values-env YTT | tee httpproxy.yaml
+  mv httpproxy.yaml spring-webdb-config/base/httpproxy.yaml
   ytt -f spring-webdb-config/base/deployment.yaml -f values.yaml --data-values-env YTT | tee deployment.yaml
   mv deployment.yaml spring-webdb-config/base/deployment.yaml
   ytt -f spring-webdb-config/base/kustomization.yaml -f values.yaml --data-values-env YTT | tee kustomization.yaml

--- a/home/workshop/setup.d/04-gitops-repo.sh
+++ b/home/workshop/setup.d/04-gitops-repo.sh
@@ -6,6 +6,9 @@ if [ $WORKSHOP_FILE == "workshop-tbs-gitops.yaml" ]
 then
   export YTT_session=${SESSION_NAMESPACE}
   export YTT_ingress__domain=${INGRESS_DOMAIN}
+  export YTT_ingress__contour_tls_namespace=${CONTOUR_TLS_NAMESPACE}
+  export YTT_ingress__contour_tls_secret=${CONTOUR_TLS_NAMESPACE}
+
   ytt -f spring-webdb-config/dev/httpproxy.yaml -f values.yaml --data-values-env YTT | tee httpproxy.yaml
   mv httpproxy.yaml spring-webdb-config/dev/httpproxy.yaml
   ytt -f spring-webdb-config/base/httpproxy.yaml -f values.yaml --data-values-env YTT | tee httpproxy.yaml


### PR DESCRIPTION
Fixed a problem where `projectcontour/contour-tls` was hardcoded as the TLS source in the GitOps repo